### PR TITLE
Fix infinite loop issue on Windows

### DIFF
--- a/lib/doing/wwid.rb
+++ b/lib/doing/wwid.rb
@@ -160,7 +160,7 @@ class WWID
   def read_config
     config = {}
     dir = Dir.pwd
-    while(dir != '/' && dir != 'C:/')
+    while (dir != '/' && (dir =~ /[A-Z]:\//) == nil)
       if File.exists? File.join(dir, DOING_CONFIG_NAME)
         config = YAML.load_file(File.join(dir, DOING_CONFIG_NAME)).deep_merge!(config)
       end


### PR DESCRIPTION
On Windows, `read_config` will never return because going up the directory tree will never result in '/'. Rather, it will get stuck at dir being 'C:/'. This fix adds this logic.

This addresses [issue 59](https://github.com/ttscoff/doing/issues/59).
