### PR TITLE
Add autotag data to WWID initializer

### DIFF
--- a/lib/doing/wwid.rb
+++ b/lib/doing/wwid.rb
@@ -21,6 +21,9 @@ class WWID
     @config = read_config
     @results = []
 
+    @config['autotag'] ||= {}
+    @config['autotag']['whitelist'] ||= []
+    @config['autotag']['synonyms'] ||= {}
     @config['doing_file'] ||= "~/what_was_i_doing.md"
     @config['current_section'] ||= 'Currently'
     @config['editor_app'] ||= nil


### PR DESCRIPTION
This was absent on the 1.0.8pre branch and resulted in errors when
running the executable. Adding it to the config here negates the need
for users running this version to write it into the file themselves.

Should resolve this issue: https://github.com/ttscoff/doing/issues/75