### PR TITLE
Hours in fmt_time() now shows correct values.

### DIFF
--- a/lib/doing/wwid.rb
+++ b/lib/doing/wwid.rb
@@ -1392,7 +1392,7 @@ EOS
     minutes =  (seconds / 60).to_i
     hours = (minutes / 60).to_i
     days = (hours / 24).to_i
-    hours = (hours % 60).to_i
+    hours = (hours % 24).to_i
     minutes = (minutes % 60).to_i
     [days, hours, minutes]
   end


### PR DESCRIPTION
The hour counter did not count 24 hours, but 60 hours in a day. When displaying totals the hour counter was off. I think this should fix it.