### PR TITLE
Make sure that read_config returns a value, instead of returning nil when there's no local_config available

### DIFF
--- a/lib/doing/wwid.rb
+++ b/lib/doing/wwid.rb
@@ -213,6 +213,7 @@ class WWID
     begin
       @config = YAML.load_file(@config_file) || {} if File.exists?(@config_file)
       @local_config = YAML.load_file(additional) || {} if additional
+      @config.deep_merge(@local_config)
     rescue
       @config = {}
       @local_config = {}


### PR DESCRIPTION
Hi Brett,

This fixes an issue where if there's no _local config_, `read_config` function returns a nil and causes an exception [here](https://github.com/dmitrym0/doing/blob/7ff9ce74922700acebb7f63e8f88c892edda8a73/lib/doing/wwid.rb#L47).

I'm not entirely sure how that would ever worked.