### PR TITLE
fixing deprecation warning. test-unit gem

### DIFF
--- a/doing.gemspec
+++ b/doing.gemspec
@@ -26,6 +26,7 @@ lib/doing/wwid.rb
   s.add_development_dependency 'rake', '~> 0'
   s.add_development_dependency 'rdoc', '~> 4.1', '>= 4.1.1'
   s.add_development_dependency 'aruba', '~> 0'
+  s.add_development_dependency 'test-unit'
   s.add_runtime_dependency('gli','~> 2.17.1')
   s.add_runtime_dependency('haml','4.0.3')
   s.add_runtime_dependency('chronic','~> 0.10', '>= 0.10.2')

--- a/lib/doing/wwid.rb
+++ b/lib/doing/wwid.rb
@@ -479,7 +479,7 @@ class WWID
             if opt[:sequential]
               done_date = next_start - 1
               next_start = item['date']
-            elsif opt[:back].instance_of? Fixnum
+            elsif opt[:back].instance_of?(Integer) || opt[:back].instance_of?(Fixnum)
               done_date = item['date'] + opt[:back]
             else
               done_date = opt[:back]


### PR DESCRIPTION
For your consideration…

* newer versions of Ruby are deprecating Fixnum for Integer.  This commit checks for Integer first then checks Fixnum.  Newer versions of ruby will not throw the deprecation warning anymore but older versions will fail on the Integer check but succeed on the Fixnum check
* added the test-unit gem because I couldn't run tests without it … even though I didn't add a test for this.  :) sorry.