### PR TITLE
Gem dependency updates

### DIFF
--- a/doing.gemspec
+++ b/doing.gemspec
@@ -30,7 +30,7 @@ lib/templates/doing.css
   s.add_development_dependency 'aruba', '~> 1.0.2'
   s.add_development_dependency 'test-unit'
   s.add_runtime_dependency 'gli', '~> 2.19', '>= 2.19.2'
-  s.add_runtime_dependency('haml','~>5.0.0', '>= 5.0.0')
+  s.add_runtime_dependency('haml','~>5.1.2', '>= 5.1.2')
   s.add_runtime_dependency('chronic','~> 0.10', '>= 0.10.2')
   s.add_runtime_dependency 'deep_merge', '~> 1.2', '>= 1.2.1'
   s.add_runtime_dependency 'json', '~> 2.3.1', '>= 1.8.1'

--- a/doing.gemspec
+++ b/doing.gemspec
@@ -27,7 +27,7 @@ lib/templates/doing.css
   s.executables << 'doing'
   s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'rdoc', '~> 4.1', '>= 4.1.1'
-  s.add_development_dependency 'aruba', '~> 0'
+  s.add_development_dependency 'aruba', '~> 1.0.2'
   s.add_development_dependency 'test-unit'
   s.add_runtime_dependency 'gli', '~> 2.17', '>= 2.17.1'
   s.add_runtime_dependency('haml','~>5.0.0', '>= 5.0.0')

--- a/doing.gemspec
+++ b/doing.gemspec
@@ -29,7 +29,7 @@ lib/templates/doing.css
   s.add_development_dependency 'rdoc', '~> 6.2.1'
   s.add_development_dependency 'aruba', '~> 1.0.2'
   s.add_development_dependency 'test-unit'
-  s.add_runtime_dependency 'gli', '~> 2.17', '>= 2.17.1'
+  s.add_runtime_dependency 'gli', '~> 2.19', '>= 2.19.2'
   s.add_runtime_dependency('haml','~>5.0.0', '>= 5.0.0')
   s.add_runtime_dependency('chronic','~> 0.10', '>= 0.10.2')
   s.add_runtime_dependency 'deep_merge', '~> 1.2', '>= 1.2.1'

--- a/doing.gemspec
+++ b/doing.gemspec
@@ -33,5 +33,5 @@ lib/templates/doing.css
   s.add_runtime_dependency('haml','~>5.0.0', '>= 5.0.0')
   s.add_runtime_dependency('chronic','~> 0.10', '>= 0.10.2')
   s.add_runtime_dependency 'deep_merge', '~> 1.2', '>= 1.2.1'
-  s.add_runtime_dependency 'json', '~> 2.2.0', '>= 1.8.1'
+  s.add_runtime_dependency 'json', '~> 2.3.1', '>= 1.8.1'
 end

--- a/doing.gemspec
+++ b/doing.gemspec
@@ -25,7 +25,7 @@ lib/templates/doing.css
   s.rdoc_options << '--title' << 'doing' << '--main' << 'README.md' << '--markup' << 'markdown' << '-ri'
   s.bindir = 'bin'
   s.executables << 'doing'
-  s.add_development_dependency 'rake', '>= 12.3.3'
+  s.add_development_dependency 'rake', '>= 13.0.1'
   s.add_development_dependency 'rdoc', '~> 6.2.1'
   s.add_development_dependency 'aruba', '~> 1.0.2'
   s.add_development_dependency 'test-unit'

--- a/doing.gemspec
+++ b/doing.gemspec
@@ -26,7 +26,7 @@ lib/templates/doing.css
   s.bindir = 'bin'
   s.executables << 'doing'
   s.add_development_dependency 'rake', '>= 12.3.3'
-  s.add_development_dependency 'rdoc', '~> 4.1', '>= 4.1.1'
+  s.add_development_dependency 'rdoc', '~> 6.2.1'
   s.add_development_dependency 'aruba', '~> 1.0.2'
   s.add_development_dependency 'test-unit'
   s.add_runtime_dependency 'gli', '~> 2.17', '>= 2.17.1'


### PR DESCRIPTION
Noticed that application dependencies could benefit from a version updates.
Made the individual Gem dependency updates as individual Git commits, just in case.

_Related issues:_

- [Gem dependency updates · Issue #106 · ttscoff/doing](https://github.com/ttscoff/doing/issues/106)

## Git commits

### chore: update gem: aruba

- Update gem: `aruba`
  - From version: `0` (wildcard)
  - To version: `1.0.2 - June 19, 2020 (79 KB)`

#### More details

- https://rubygems.org/gems/aruba


### chore: update gem: json

- Update gem: `json`
  - From version: `2.2.0 - February 21, 2019 (110 KB)`
  - To version: `2.3.1 - June 30, 2020 (116 KB)`
  - Latest releases:
    - 2020-06-30 (2.3.1)
    - 2019-12-11 (2.3.0)
      - `[CVE-2020-10663]` security

#### More details

- https://rubygems.org/gems/json
- https://github.com/flori/json/blob/master/CHANGES.md#2020-06-30-231


### chore: update gem: rdoc

- Update gem: `rdoc`
  - From version: `4.1.1 - January 09, 2014 (717 KB)`
  - To version: `6.2.1 - December 23, 2019 (551 KB)`

#### More details

- https://rubygems.org/gems/rdoc


### chore: update gem: rake

- Update gem: `rake`
  - From version: `12.3.3 - July 22, 2019 (85 KB)`
  - To version: `13.0.1 - November 12, 2019 (85.5 KB)`
  - Latest releases:
    - 13.0.1 (November 12, 2019)

#### More details

- https://rubygems.org/gems/rake
- https://github.com/ruby/rake/blob/v13.0.1/History.rdoc#1301-


### chore: update gem: gli

- Update gem: `gli`
  - From version: `2.17.0 - October 22, 2017 (75.5 KB)`
  - To version: `2.19.2 - June 26, 2020 (77 KB)`

More details:

- https://rubygems.org/gems/gli


### chore: update gem: haml

- Update gem: `haml`
  - From version: `5.0.0 - April 27, 2017 (122 KB)`
  - To version: `5.1.2 - August 06, 2019 (88.5 KB)`

#### More details

- https://rubygems.org/gems/haml
